### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Fox
 maintainer=Allester Fox <fox.axon@gmail.com>
 sentence=XPT2046 Library for STM32
 paragraph=XPT2046 Library for STM32
-category=Touch
+category=Display
 url=https://github.com/FoxExe/STM32_XPT2046
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Touch' in library XPT2046_STM is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format